### PR TITLE
Set Authorization header via ENV var

### DIFF
--- a/http.go
+++ b/http.go
@@ -53,8 +53,8 @@ func probeHTTP(target string, w http.ResponseWriter, module Module) (success boo
 	}
 
 	// Set the sentry Bearer Auth token from the ENV var
-	authToken, present := os.LookupEnv("AUTH_TOKEN")
-	if present {
+	authToken, ok := os.LookupEnv("AUTH_TOKEN")
+	if ok {
 		request.Header.Set("Authorization", authToken)
 	}
 

--- a/http.go
+++ b/http.go
@@ -53,9 +53,9 @@ func probeHTTP(target string, w http.ResponseWriter, module Module) (success boo
 	}
 
 	// Set the sentry Bearer Auth token from the ENV var
-	auth_token := os.Getenv("AUTH_TOKEN")
-	if auth_token != nil {
-		request.Header.Set("Authorization", auth_token)
+	authToken, present := os.LookupEnv("AUTH_TOKEN")
+	if present {
+		request.Header.Set("Authorization", authToken)
 	}
 
 	resp, err := client.Do(request)

--- a/http.go
+++ b/http.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -49,6 +50,12 @@ func probeHTTP(target string, w http.ResponseWriter, module Module) (success boo
 			continue
 		}
 		request.Header.Set(key, value)
+	}
+
+	// Set the sentry Bearer Auth token from the ENV var
+	auth_token := os.Getenv("AUTH_TOKEN")
+	if auth_token != nil {
+		request.Header.Set("Authorization", auth_token)
 	}
 
 	resp, err := client.Do(request)


### PR DESCRIPTION
Instead of relying on the sentry_exporter.yml config file, we also support setting the authorization bearer token via an ENV var.